### PR TITLE
Change "POJO" wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ app
     └── en.js
 ```
 
-Then export a single POJO:
+Then export a single JavaScript object:
 
 ```javascript
 export default {


### PR DESCRIPTION
I haven't seen the POJO in common use, and found it confusing (it made me stop in my tracks,
do a web search, and then key into the fact that it likely stood for "plain ol' JavaScript object).

Rather than making every reader do this, why not just call it a JS object? It's less clever, less
verbose, and easier to read.
