### PR TITLE
Add test confirming all locales have all keys.

### DIFF
--- a/test-support/ember-cli-i18n-test.js
+++ b/test-support/ember-cli-i18n-test.js
@@ -1,0 +1,40 @@
+/* globals requirejs, require */
+
+import Ember from 'ember';
+import config from '../config/environment';
+
+var keys = Ember.keys;
+
+var locales, defaultLocale;
+module('ember-cli-i18n', {
+  setup: function() {
+    var localRegExp = new RegExp(config.modulePrefix + '/locales/(.+)');
+    var match, moduleName;
+
+    locales = {};
+
+    for (moduleName in requirejs.entries) {
+      if (match = moduleName.match(localRegExp)) {
+        locales[match[1]] = require(moduleName)['default'];
+      }
+    }
+
+    defaultLocale = locales[config.APP.defaultLocale];
+  }
+});
+
+test('locales all contain the same keys', function() {
+  var knownLocales = keys(locales);
+
+  for (var i = 0, l = knownLocales.length; i < l; i++) {
+    var currentLocale = locales[knownLocales[i]];
+
+    if (currentLocale === defaultLocale) {
+      continue;
+    }
+
+    for (var translationKey in defaultLocale) {
+      ok(currentLocale[translationKey], '`' + translationKey + '` should exist in the `' + knownLocales[i] + '` locale.');
+    }
+  }
+});


### PR DESCRIPTION
Something that has bit our team a few times: we add a new key to the default locale file, but forget to add it to the others.

This adds an test that runs in the consuming app, that confirms all locale files contain the keys from the `defaultLocale`.
