### PR TITLE
Show how values for interpolation are passed to t

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ You can add keys for interpolation
 
 ```javascript
 export default {
-  age: 'You are %@1 years old.'
+  age: 'You are %@1 years old.',
+  name: '%@, %@'
 };
 ```
 
@@ -123,10 +124,11 @@ export default Ember.Object.extend({
 ```javascript
 export default DS.Model.extend({
   name: function() {
-    return this.t('name');
+    return this.t('name', 'John', 'Doe');
   }
 });
 ```
+Note that interpolation values can also be passed as an array if you prefer this style. `this.t('name', ['John', 'Doe'])` 
 
 ## Authors ##
 


### PR DESCRIPTION
the interpolation values have to be passed as an array to this.t because of readArray in https://github.com/dockyard/ember-cli-i18n/blob/71cc781abb/addon/utils/t.js#L30. I first passed in a string, but only saw the first letter of it being interpolated. Took me a moment to figure out the reason...so I thought this info might be helpful in the readme.
