### PR TITLE
Fixes t helper when used in controllers, components etc.

### DIFF
--- a/addon/utils/t.js
+++ b/addon/utils/t.js
@@ -27,7 +27,7 @@ function T(attributes) {
 
     result = get(locale, read(path));
 
-    return fmt(result, readArray(values));
+    return fmt(result, readArray(values || []));
   };
 
   this.lookupLocale = function(countryCode) {


### PR DESCRIPTION
If there are no interpolation values for a translation (e.g. just `this.t('name')`) `return fmt(result, readArray(values));` fails as `values` is undefined. When called as a Handlebars helper, values are passed as an empty array when the argument is missing so that works.
