### PR TITLE
Don't fail test when there's only one locale

### DIFF
--- a/test-support/ember-cli-i18n-test.js
+++ b/test-support/ember-cli-i18n-test.js
@@ -25,6 +25,10 @@ module('ember-cli-i18n', {
 
 test('locales all contain the same keys', function() {
   var knownLocales = keys(locales);
+  if (knownLocales.length === 1) {
+    expect(0);
+    return;
+  }
 
   for (var i = 0, l = knownLocales.length; i < l; i++) {
     var currentLocale = locales[knownLocales[i]];


### PR DESCRIPTION
The test failed for me as I only had the `en` locale initially although there's actually nothing wrong.
