### PR TITLE
Handle missing or bad translations

### DIFF
--- a/addon/utils/t.js
+++ b/addon/utils/t.js
@@ -30,6 +30,8 @@ function T(attributes) {
     }
 
     result = get(locale, read(path));
+    Ember.assert('Missing translation for key "' + path + '".', result);
+    Ember.assert('Translation for key "' + path + '" is not a string.', Ember.typeOf(result) === 'string');
 
     return fmt(result, readArray(values));
   };

--- a/tests/unit/utils/t-test.js
+++ b/tests/unit/utils/t-test.js
@@ -119,3 +119,15 @@ test('can take array arguments', function() {
 
   equal(t('name', ['John', 'Doe']), 'John Doe');
 });
+
+test('throws on missing keys', function() {
+  application.defaultLocale = 'en';
+
+  throws(function() { t('missing'); });
+});
+
+test('throws on non-string values', function() {
+  application.defaultLocale = 'en';
+
+  throws(function() { t('home'); });
+});


### PR DESCRIPTION
handles missing keys as well as bad values (where the value is an object), see #16 
